### PR TITLE
Return the argumentValue when guard is passed

### DIFF
--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingEmpty_Enumerable.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingEmpty_Enumerable.cs
@@ -43,11 +43,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNotNullOrEmptyString_ShouldNotThrow()
         {
             var myArgument = new[] {1};
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingEmpty(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingEmpty(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -61,11 +64,13 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNullEnumerable_ShouldNotThrow()
         {
             var myArgument = default(int[]);
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingEmpty(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingEmpty(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.Equal(myArgument, result);
         }
     }
 }

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingEmpty_String.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingEmpty_String.cs
@@ -42,11 +42,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNotNullOrEmptyString_ShouldNotThrow()
         {
             var myArgument = " blah ";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingEmpty(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingEmpty(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -59,11 +62,13 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNullString_ShouldNotThrow()
         {
             var myArgument = default(string);
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingEmpty(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingEmpty(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.Equal(myArgument, result);
         }
     }
 }

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingGreaterThanMaximum.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingGreaterThanMaximum.cs
@@ -19,11 +19,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMaximum_ShouldNotThrow()
         {
             var myArgument = "A";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingGreaterThanMaximum(myArgument, "A", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingGreaterThanMaximum(myArgument, "A", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -52,11 +55,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsLessThanMaximum_ShouldNotThrow()
         {
             var myArgument = "A";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingGreaterThanMaximum(myArgument, "B", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingGreaterThanMaximum(myArgument, "B", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -69,11 +75,13 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNull_ShouldNotThrow()
         {
             var myArgument = default(string);
+            object result = null;
             Should.NotThrow(() =>
             {
                 GuardAgainst.ArgumentBeingGreaterThanMaximum(myArgument, "B", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingGreaterThanMaximumForValueType.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingGreaterThanMaximumForValueType.cs
@@ -24,11 +24,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMaximum_ShouldNotThrow()
         {
             var myArgument = 1;
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingGreaterThanMaximum(myArgument, 2, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingGreaterThanMaximum(myArgument, 2, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -57,11 +60,13 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsLessThanMaximum_ShouldNotThrow()
         {
             var myArgument = 1;
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingGreaterThanMaximum(myArgument, 2, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingGreaterThanMaximum(myArgument, 2, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.Equal(myArgument, result);
         }
     }
 }

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingInvalid.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingInvalid.cs
@@ -26,11 +26,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsFalse_ShouldNotThrow()
         {
             var myArgument = false;
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingInvalid(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingInvalid(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingLessThanMinimum.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingLessThanMinimum.cs
@@ -26,11 +26,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMinimum_ShouldNotThrow()
         {
             var myArgument = "A";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, "A", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, "A", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -44,11 +47,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsGreaterThanMinimum_ShouldNotThrow()
         {
             var myArgument = "B";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, "A", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, "A", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -70,22 +76,27 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNull_ShouldNotThrowException()
         {
             var myArgument = default(string);
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, "B", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, "B", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
         public void WhenMinimumValueIsNull_ShouldNotThrow()
         {
             var myArgument = "A";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, null, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, null, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
     }
 }

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingLessThanMinimumForValueType.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingLessThanMinimumForValueType.cs
@@ -24,11 +24,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMinimum_ShouldNotThrow()
         {
             var myArgument = 1;
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, 1, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, 1, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -42,11 +45,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsGreaterThanMinimum_ShouldNotThrow()
         {
             var myArgument = 2;
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, 1, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingLessThanMinimum(myArgument, 1, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingNull.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingNull.cs
@@ -38,11 +38,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNotNull_ShouldNotThrow()
         {
             var myArgument = "Hello, World!";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNull(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNull(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrEmpty_Enumerable.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrEmpty_Enumerable.cs
@@ -43,11 +43,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNotNullOrEmpty_ShouldNotThrow()
         {
             var myArgument = new[] {"blah"};
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrEmpty(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrEmpty(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrEmpty_String.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrEmpty_String.cs
@@ -42,11 +42,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNotNullOrEmpty_ShouldNotThrow()
         {
             var myArgument = " blah ";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrEmpty(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrEmpty(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrGreaterThanMaximum.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrGreaterThanMaximum.cs
@@ -26,11 +26,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMaximum_ShouldNotThrow()
         {
             var myArgument = "A";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrGreaterThanMaximum(myArgument, "A", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrGreaterThanMaximum(myArgument, "A", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -59,11 +62,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsLessThanMaximum_ShouldNotThrow()
         {
             var myArgument = "A";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrGreaterThanMaximum(myArgument, "B", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrGreaterThanMaximum(myArgument, "B", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrLessThanMinimum.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrLessThanMinimum.cs
@@ -26,11 +26,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMinimum_ShouldNotThrow()
         {
             var myArgument = "A";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrLessThanMinimum(myArgument, "A", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrLessThanMinimum(myArgument, "A", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -44,11 +47,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsGreaterThanMinimum_ShouldNotThrow()
         {
             var myArgument = "B";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrLessThanMinimum(myArgument, "A", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrLessThanMinimum(myArgument, "A", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -85,11 +91,14 @@ namespace GuardAgainstLib.Test
         public void WhenMinimumValueIsNull_ShouldNotThrow()
         {
             var myArgument = "A";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrLessThanMinimum(myArgument, null, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrLessThanMinimum(myArgument, null, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
     }
 }

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrOutOfRange.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrOutOfRange.cs
@@ -26,11 +26,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMaximum_ShouldNotThrow()
         {
             var myArgument = "D";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -44,11 +47,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMinimum_ShouldNotThrow()
         {
             var myArgument = "B";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -76,11 +82,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsInRange_ShouldNotThrow()
         {
             var myArgument = "C";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -130,11 +139,14 @@ namespace GuardAgainstLib.Test
         public void WhenMinimumValueIsNull_ShouldNotThrow()
         {
             var myArgument = "A";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrOutOfRange(myArgument, null, "D", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrOutOfRange(myArgument, null, "D", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
     }
 }

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrWhitespace.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingNullOrWhitespace.cs
@@ -26,11 +26,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNotNullOrWhitespace_ShouldNotThrow()
         {
             var myArgument = " blah ";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingNullOrWhitespace(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingNullOrWhitespace(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingOutOfRange.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingOutOfRange.cs
@@ -26,11 +26,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMaximum_ShouldNotThrow()
         {
             var myArgument = "D";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -44,11 +47,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMinimum_ShouldNotThrow()
         {
             var myArgument = "B";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -76,11 +82,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsInRange_ShouldNotThrow()
         {
             var myArgument = "C";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -108,11 +117,13 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentValueIsNull_ShouldNotThrow()
         {
             var myArgument = default(string);
+            object result = null;
             Should.NotThrow(() =>
             {
                 GuardAgainst.ArgumentBeingOutOfRange(myArgument, "B", "D", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -133,11 +144,14 @@ namespace GuardAgainstLib.Test
         public void WhenMinimumValueIsNull_ShouldNotThrow()
         {
             var myArgument = "A";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingOutOfRange(myArgument, null, "D", nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingOutOfRange(myArgument, null, "D", nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
     }
 }

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingOutOfRangeForValueType.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingOutOfRangeForValueType.cs
@@ -24,11 +24,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMaximum_ShouldNotThrow()
         {
             var myArgument = 4;
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingOutOfRange(myArgument, 2, 4, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingOutOfRange(myArgument, 2, 4, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -42,11 +45,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsEqualToMinimum_ShouldNotThrow()
         {
             var myArgument = 2;
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingOutOfRange(myArgument, 2, 4, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingOutOfRange(myArgument, 2, 4, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -74,11 +80,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsInRange_ShouldNotThrow()
         {
             var myArgument = 3;
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingOutOfRange(myArgument, 2, 4, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingOutOfRange(myArgument, 2, 4, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingUnspecifiedDateTime.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingUnspecifiedDateTime.cs
@@ -17,12 +17,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentValueIsLocal_ShouldNotThrow()
         {
             var myArgument = DateTime.UtcNow;
-
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingUnspecifiedDateTime(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingUnspecifiedDateTime(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
@@ -50,12 +52,14 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentValueIsUtc_ShouldNotThrow()
         {
             var myArgument = DateTime.UtcNow;
-
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingUnspecifiedDateTime(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingUnspecifiedDateTime(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
     }
 }

--- a/src/GuardAgainstLib.Test/Test_ArgumentBeingWhitespace.cs
+++ b/src/GuardAgainstLib.Test/Test_ArgumentBeingWhitespace.cs
@@ -26,22 +26,27 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsNotWhitespace_ShouldNotThrow()
         {
             var myArgument = " blah ";
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingWhitespace(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingWhitespace(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]
         public void WhenArgumentIsNull_ShouldNotThrowArgumentNullException()
         {
             var myArgument = default(string);
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.ArgumentBeingWhitespace(myArgument, nameof(myArgument), null,
+                result = GuardAgainst.ArgumentBeingWhitespace(myArgument, nameof(myArgument), null,
                     new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib.Test/Test_OperationBeingInvalid.cs
+++ b/src/GuardAgainstLib.Test/Test_OperationBeingInvalid.cs
@@ -25,10 +25,13 @@ namespace GuardAgainstLib.Test
         public void WhenArgumentIsFalse_ShouldNotThrow()
         {
             var myArgument = false;
+            object result = null;
             Should.NotThrow(() =>
             {
-                GuardAgainst.OperationBeingInvalid(myArgument, null, new Dictionary<object, object> {{"a", "1"}});
+                result = GuardAgainst.OperationBeingInvalid(myArgument, null, new Dictionary<object, object> {{"a", "1"}});
             });
+            Assert.NotNull(result);
+            Assert.Equal(myArgument, result);
         }
 
         [Fact]

--- a/src/GuardAgainstLib/GuardAgainst.cs
+++ b/src/GuardAgainstLib/GuardAgainst.cs
@@ -37,7 +37,7 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingNull<T>(T argumentValue,
+        public static T ArgumentBeingNull<T>(T argumentValue,
                                                 string argumentName = null,
                                                 string exceptionMessage = null,
                                                 IDictionary<object, object> additionalData = default)
@@ -45,7 +45,7 @@ namespace GuardAgainstLib
         {
             if (!ReferenceEquals(argumentValue, null))
             {
-                return;
+                return argumentValue;
             }
 
             var ex = new ArgumentNullException(argumentName.ToNullIfWhitespace(),
@@ -81,14 +81,14 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingNullOrWhitespace(string argumentValue,
+        public static string ArgumentBeingNullOrWhitespace(string argumentValue,
                                                          string argumentName = null,
                                                          string exceptionMessage = null,
                                                          IDictionary<object, object> additionalData = default)
         {
             if (!string.IsNullOrWhiteSpace(argumentValue))
             {
-                return;
+                return argumentValue;
             }
 
             if (ReferenceEquals(argumentValue, null))
@@ -134,14 +134,14 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingWhitespace(string argumentValue,
+        public static string ArgumentBeingWhitespace(string argumentValue,
                                                    string argumentName = null,
                                                    string exceptionMessage = null,
                                                    IDictionary<object, object> additionalData = default)
         {
             if (ReferenceEquals(argumentValue, null) || !string.IsNullOrWhiteSpace(argumentValue))
             {
-                return;
+                return argumentValue;
             }
 
             var ex = new ArgumentException(exceptionMessage.ToNullIfWhitespace(), argumentName.ToNullIfWhitespace());
@@ -180,7 +180,7 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingNullOrLessThanMinimum<T>(T argumentValue,
+        public static T ArgumentBeingNullOrLessThanMinimum<T>(T argumentValue,
                                                                  T minimumAllowedValue,
                                                                  string argumentName = null,
                                                                  string exceptionMessage = null,
@@ -204,6 +204,8 @@ namespace GuardAgainstLib
                 ex.AddData(additionalData);
                 throw ex;
             }
+
+            return argumentValue;
         }
 
         /// <summary>
@@ -235,7 +237,7 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingLessThanMinimum<T>(T argumentValue,
+        public static T ArgumentBeingLessThanMinimum<T>(T argumentValue,
                                                            T minimumAllowedValue,
                                                            string argumentName = null,
                                                            string exceptionMessage = null,
@@ -244,7 +246,7 @@ namespace GuardAgainstLib
         {
             if (ReferenceEquals(argumentValue, null))
             {
-                return;
+                return argumentValue;
             }
 
             if (argumentValue.IsLessThan(minimumAllowedValue))
@@ -255,6 +257,8 @@ namespace GuardAgainstLib
                 ex.AddData(additionalData);
                 throw ex;
             }
+
+            return argumentValue;
         }
 
         /// <summary>
@@ -288,7 +292,7 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingNullOrGreaterThanMaximum<T>(T argumentValue,
+        public static T ArgumentBeingNullOrGreaterThanMaximum<T>(T argumentValue,
                                                                     T maximumAllowedValue,
                                                                     string argumentName = null,
                                                                     string exceptionMessage = null,
@@ -313,6 +317,8 @@ namespace GuardAgainstLib
                 ex.AddData(additionalData);
                 throw ex;
             }
+
+            return argumentValue;
         }
 
         /// <summary>
@@ -344,7 +350,7 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingGreaterThanMaximum<T>(T argumentValue,
+        public static T ArgumentBeingGreaterThanMaximum<T>(T argumentValue,
                                                               T maximumAllowedValue,
                                                               string argumentName = null,
                                                               string exceptionMessage = null,
@@ -353,7 +359,7 @@ namespace GuardAgainstLib
         {
             if (ReferenceEquals(argumentValue, null))
             {
-                return;
+                return argumentValue;
             }
 
             if (argumentValue.IsMoreThan(maximumAllowedValue))
@@ -364,6 +370,8 @@ namespace GuardAgainstLib
                 ex.AddData(additionalData);
                 throw ex;
             }
+
+            return argumentValue;
         }
 
 
@@ -399,7 +407,7 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingNullOrOutOfRange<T>(T argumentValue,
+        public static T ArgumentBeingNullOrOutOfRange<T>(T argumentValue,
                                                             T minimumAllowedValue,
                                                             T maximumAllowedValue,
                                                             string argumentName = null,
@@ -424,6 +432,8 @@ namespace GuardAgainstLib
                 ex.AddData(additionalData);
                 throw ex;
             }
+
+            return argumentValue;
         }
 
         /// <summary>
@@ -456,7 +466,7 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingOutOfRange<T>(T argumentValue,
+        public static T ArgumentBeingOutOfRange<T>(T argumentValue,
                                                       T minimumAllowedValue,
                                                       T maximumAllowedValue,
                                                       string argumentName = null,
@@ -466,7 +476,7 @@ namespace GuardAgainstLib
         {
             if (ReferenceEquals(argumentValue, null))
             {
-                return;
+                return argumentValue;
             }
 
             if (!argumentValue.IsInRange(minimumAllowedValue, maximumAllowedValue))
@@ -477,6 +487,8 @@ namespace GuardAgainstLib
                 ex.AddData(additionalData);
                 throw ex;
             }
+
+            return argumentValue;
         }
 
         /// <summary>
@@ -504,14 +516,14 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingInvalid(bool argumentValueInvalid,
+        public static bool ArgumentBeingInvalid(bool argumentValueInvalid,
                                                 string argumentName = null,
                                                 string exceptionMessage = null,
                                                 IDictionary<object, object> additionalData = default)
         {
             if (!argumentValueInvalid)
             {
-                return;
+                return argumentValueInvalid;
             }
 
             var ex = new ArgumentException(exceptionMessage.ToNullIfWhitespace(), argumentName.ToNullIfWhitespace());
@@ -540,13 +552,13 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void OperationBeingInvalid(bool operationInvalid,
+        public static bool OperationBeingInvalid(bool operationInvalid,
                                                  string exceptionMessage = null,
                                                  IDictionary<object, object> additionalData = default)
         {
             if (!operationInvalid)
             {
-                return;
+                return operationInvalid;
             }
 
             var ex = new InvalidOperationException(exceptionMessage.ToNullIfWhitespace());
@@ -576,14 +588,14 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingUnspecifiedDateTime(DateTime argumentValue,
+        public static DateTime ArgumentBeingUnspecifiedDateTime(DateTime argumentValue,
                                                             string argumentName = null,
                                                             string exceptionMessage = null,
                                                             IDictionary<object, object> additionalData = default)
         {
             if (argumentValue.Kind != DateTimeKind.Unspecified)
             {
-                return;
+                return argumentValue;
             }
 
             var ex = new ArgumentException(exceptionMessage.ToNullIfWhitespace(), argumentName.ToNullIfWhitespace());
@@ -618,14 +630,14 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingNullOrEmpty(string argumentValue,
+        public static string ArgumentBeingNullOrEmpty(string argumentValue,
                                                     string argumentName = null,
                                                     string exceptionMessage = null,
                                                     IDictionary<object, object> additionalData = default)
         {
             if (!string.IsNullOrEmpty(argumentValue))
             {
-                return;
+                return argumentValue;
             }
 
             if (ReferenceEquals(argumentValue, null))
@@ -673,7 +685,7 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingNullOrEmpty<T>(IEnumerable<T> argumentValue,
+        public static IEnumerable<T> ArgumentBeingNullOrEmpty<T>(IEnumerable<T> argumentValue,
                                                        string argumentName = null,
                                                        string exceptionMessage = null,
                                                        IDictionary<object, object> additionalData = default)
@@ -693,6 +705,8 @@ namespace GuardAgainstLib
                 ex.AddData(additionalData);
                 throw ex;
             }
+
+            return argumentValue;
         }
 
         /// <summary>
@@ -720,14 +734,14 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingEmpty(string argumentValue,
+        public static string ArgumentBeingEmpty(string argumentValue,
                                               string argumentName = null,
                                               string exceptionMessage = null,
                                               IDictionary<object, object> additionalData = default)
         {
             if (ReferenceEquals(argumentValue, null) || !string.IsNullOrEmpty(argumentValue))
             {
-                return;
+                return argumentValue;
             }
 
             var ex = new ArgumentException(exceptionMessage.ToNullIfWhitespace(), argumentName.ToNullIfWhitespace());
@@ -760,14 +774,14 @@ namespace GuardAgainstLib
         /// }
         /// </code>
         /// </example>
-        public static void ArgumentBeingEmpty<T>(IEnumerable<T> argumentValue,
+        public static IEnumerable<T> ArgumentBeingEmpty<T>(IEnumerable<T> argumentValue,
                                                  string argumentName = null,
                                                  string exceptionMessage = null,
                                                  IDictionary<object, object> additionalData = default)
         {
             if (ReferenceEquals(argumentValue, default(IEnumerable<T>)) || argumentValue.Any())
             {
-                return;
+                return argumentValue;
             }
 
             var ex = new ArgumentException(exceptionMessage.ToNullIfWhitespace(), argumentName.ToNullIfWhitespace());


### PR DESCRIPTION
Sometimes you want to execute GuardAgainst and do a variable assignment in the same line, sadly it's not possible with the current version.

**Before**
```csharp
public class Employee
{
    public string Name {get; private set;}

    public void SetName(string name)
    {
        GuardAgainst.ArgumentBeingNullOrWhitespace(name, nameof(name));
        Name = name;
    }
}
```

**After**
```csharp
public class Employee
{
    public string Name {get; private set;}

    public void SetName(string name)
    {
        Name = GuardAgainst.ArgumentBeingNullOrWhitespace(name, nameof(name));
    }
}
```